### PR TITLE
Fix crafting recipe issues, bump version/game version

### DIFF
--- a/assets/instruments/recipes/grid/accordion.json
+++ b/assets/instruments/recipes/grid/accordion.json
@@ -3,7 +3,7 @@
 	ingredients: {
 		"B": { type: "item", code: "game:bone", "quantity": 3},
 		"P": { type: "item", code: "game:plank-*" },
-		"L": { type: "item", code: "game:leather", "quantity": 2 }
+		"L": { type: "item", code: "game:leather-plain", "quantity": 2 }
 	},
 	width: 3,
 	height: 2,

--- a/assets/instruments/recipes/grid/drum.json
+++ b/assets/instruments/recipes/grid/drum.json
@@ -1,7 +1,7 @@
 {
 	ingredientPattern: "PLP	PPP",
 	ingredients: {
-		"L": { type: "item", code: "game:leather"},
+		"L": { type: "item", code: "game:leather-plain"},
 		"P": { type: "item", code: "game:plank-*" }
 	},
 	width: 3,

--- a/modinfo.json
+++ b/modinfo.json
@@ -4,9 +4,9 @@
   "name": "Instruments",
   "description": "Play some tunes together on a variety of instruments!",
   "author": "Quacksol",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "dependency": {
-    "game": "1.15.02"
+    "game": "1.16.0"
   }
 }
 


### PR DESCRIPTION
`game:leather` was updated to `game:leather-plain` in v1.16.0.
I made a naive bump to game version in the `modinfo.json` since I've not seen other issues with the game/mod in v1.16.0.