### PR TITLE
fix: adjust default octave

### DIFF
--- a/src/ABCParser.cs
+++ b/src/ABCParser.cs
@@ -445,7 +445,7 @@ namespace instruments
         {
             Note newNote = new Note();
             int noteIndex = -1;
-            int octaveIndex = 3; // 4 is middle, but 2 sounds MUCH better - start there
+            int octaveIndex = 2; // 4 is middle, but 2 sounds MUCH better - start there
             bool sharpDetected = false;
             bool flatDetected = false;
             bool naturalDetected = false;


### PR DESCRIPTION
The default octave is incorrect and many instruments play strangely. Flipping a single bit of the source code corrects for this mistake. 

Please compare recordings from before and after, as well as the ABC -> MIDI rendering from the same file using a custom sound font derived from the samples used in the mod.

Before: 

[before.webm](https://github.com/user-attachments/assets/b76e433c-bb42-4629-aeb3-3fd589b5739d)

After: 

[after.webm](https://github.com/user-attachments/assets/f2a6513a-e3f6-42c3-adae-1c121c4bfcd9)

ABC -> MIDI:

[allstar_filtered.webm](https://github.com/user-attachments/assets/67c73a66-f9a1-4541-8f6e-2c28ef10a742)


